### PR TITLE
Firmware Sliders: integrating new MSP commands - first look

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -674,6 +674,9 @@ const FC = {
             slider_i_gain:                      0,
             slider_roll_pitch_ratio:            0,
             slider_pitch_pi_gain:               0,
+            slider_pids_valid:                  0,
+            slider_gyro_valid:                  0,
+            slider_dterm_valid:                 0,
         };
 
         this.DEFAULT_TUNING_SLIDERS = {
@@ -691,6 +694,10 @@ const FC = {
             slider_dterm_filter_multiplier:     100,
             slider_gyro_filter:                 1,
             slider_gyro_filter_multiplier:      100,
+
+            slider_pids_valid:                  1,
+            slider_gyro_valid:                  1,
+            slider_dterm_valid:                 1,
         };
     },
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -252,13 +252,6 @@ function startProcess() {
             const tabName = $(self).text();
             let timeout = 0;
 
-            if (GUI.active_tab === 'pid_tuning') {
-                if (TABS.pid_tuning.retainConfiguration) {
-                    TABS.pid_tuning.restoreInitialSettings();
-                    timeout = 500;
-                }
-            }
-
             if (tabRequiresConnection && !CONFIGURATOR.connectionValid) {
                 GUI.log(i18n.getMessage('tabSwitchConnectionRequired'));
                 return;

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -120,6 +120,16 @@ const MSPCodes = {
     MSP_TUNING_SLIDERS:             140,
     MSP_SET_TUNING_SLIDERS:         141,
 
+    MSP_CALC_PID_TUNING_SLIDERS:    142,    // calculate slider values in temp profile
+    MSP_CALC_GYRO_TUNING_SLIDERS:   143,
+    MSP_CALC_DTERM_TUNING_SLIDERS:  144,
+
+    MSP_VALIDATE_TUNING_SLIDERS:    145,    // validate slider values in temp profile
+
+    MSP_APPLY_PID_TUNING_SLIDERS:   146,    // copy slider values to profile
+    MSP_APPLY_GYRO_TUNING_SLIDERS:  147,
+    MSP_APPLY_DTERM_TUNING_SLIDERS: 148,
+
     MSP_STATUS_EX:                  150,
 
     MSP_UID:                        160,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1505,6 +1505,40 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.TUNING_SLIDERS.slider_gyro_filter_multiplier = data.readU8();
                 break;
 
+            case MSPCodes.MSP_CALC_PID_TUNING_SLIDERS:
+                // TODO
+                break;
+
+            case MSPCodes.MSP_CALC_GYRO_TUNING_SLIDERS:
+                FC.FILTER_CONFIG.gyro_lowpass_hz = data.readU16();
+                FC.FILTER_CONFIG.gyro_lowpass2_hz = data.readU16();
+                FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz = data.readU16();
+                FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz = data.readU16();
+
+                break;
+            case MSPCodes.MSP_CALC_DTERM_TUNING_SLIDERS:
+                FC.FILTER_CONFIG.dterm_lowpass_hz = data.readU16();
+                FC.FILTER_CONFIG.dterm_lowpass2_hz = data.readU16();
+                FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz = data.readU16();
+                FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz = data.readU16();
+
+                break;
+
+            case MSPCodes.MSP_VALIDATE_TUNING_SLIDERS:
+                FC.TUNING_SLIDERS.slider_pids_valid = data.readU8();
+                FC.TUNING_SLIDERS.slider_gyro_valid = data.readU8();
+                FC.TUNING_SLIDERS.slider_dterm_valid = data.readU8();
+                break;
+
+            case MSPCodes.MSP_APPLY_PID_TUNING_SLIDERS:
+                break;
+
+            case MSPCodes.MSP_APPLY_GYRO_TUNING_SLIDERS:
+                break;
+
+            case MSPCodes.MSP_APPLY_DTERM_TUNING_SLIDERS:
+                break;
+
             case MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL:
                 console.log("VTX powerlevel sent");
                 break;
@@ -2315,19 +2349,50 @@ MspHelper.prototype.crunch = function(code) {
 
         case MSPCodes.MSP_SET_TUNING_SLIDERS:
             buffer
-                .push8(FC.TUNING_SLIDERS.slider_pids_mode)
-                .push8(FC.TUNING_SLIDERS.slider_master_multiplier)
-                .push8(FC.TUNING_SLIDERS.slider_roll_pitch_ratio)
-                .push8(FC.TUNING_SLIDERS.slider_i_gain)
-                .push8(FC.TUNING_SLIDERS.slider_d_gain)
-                .push8(FC.TUNING_SLIDERS.slider_pi_gain)
-                .push8(FC.TUNING_SLIDERS.slider_dmax_gain)
-                .push8(FC.TUNING_SLIDERS.slider_feedforward_gain)
-                .push8(FC.TUNING_SLIDERS.slider_pitch_pi_gain)
-                .push8(FC.TUNING_SLIDERS.slider_dterm_filter)
-                .push8(FC.TUNING_SLIDERS.slider_dterm_filter_multiplier)
-                .push8(FC.TUNING_SLIDERS.slider_gyro_filter)
-                .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier);
+            .push8(FC.TUNING_SLIDERS.slider_pids_mode)
+            .push8(FC.TUNING_SLIDERS.slider_master_multiplier)
+            .push8(FC.TUNING_SLIDERS.slider_roll_pitch_ratio)
+            .push8(FC.TUNING_SLIDERS.slider_i_gain)
+            .push8(FC.TUNING_SLIDERS.slider_d_gain)
+            .push8(FC.TUNING_SLIDERS.slider_pi_gain)
+            .push8(FC.TUNING_SLIDERS.slider_dmax_gain)
+            .push8(FC.TUNING_SLIDERS.slider_feedforward_gain)
+            .push8(FC.TUNING_SLIDERS.slider_pitch_pi_gain)
+            .push8(FC.TUNING_SLIDERS.slider_dterm_filter)
+            .push8(FC.TUNING_SLIDERS.slider_dterm_filter_multiplier)
+            .push8(FC.TUNING_SLIDERS.slider_gyro_filter)
+            .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier);
+
+            break;
+        case MSPCodes.MSP_CALC_PID_TUNING_SLIDERS:
+            buffer
+            .push8(FC.TUNING_SLIDERS.slider_pids_mode)
+            .push8(FC.TUNING_SLIDERS.slider_master_multiplier)
+            .push8(FC.TUNING_SLIDERS.slider_roll_pitch_ratio)
+            .push8(FC.TUNING_SLIDERS.slider_i_gain)
+            .push8(FC.TUNING_SLIDERS.slider_d_gain)
+            .push8(FC.TUNING_SLIDERS.slider_pi_gain)
+            .push8(FC.TUNING_SLIDERS.slider_dmax_gain)
+            .push8(FC.TUNING_SLIDERS.slider_feedforward_gain)
+            .push8(FC.TUNING_SLIDERS.slider_pitch_pi_gain);
+
+            break;
+
+        case MSPCodes.MSP_CALC_GYRO_TUNING_SLIDERS:
+            buffer
+            .push16(FC.FILTER_CONFIG.gyro_lowpass_hz)
+            .push16(FC.FILTER_CONFIG.gyro_lowpass2_hz)
+            .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz)
+            .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz);
+
+            break;
+        case MSPCodes.MSP_CALC_DTERM_TUNING_SLIDERS:
+            buffer
+            .push16(FC.FILTER_CONFIG.dterm_lowpass_hz)
+            .push16(FC.FILTER_CONFIG.dterm_lowpass2_hz)
+            .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz)
+            .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
+
             break;
 
         default:

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1506,7 +1506,28 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
 
             case MSPCodes.MSP_CALC_PID_TUNING_SLIDERS:
-                // TODO
+                FC.PIDS[0][0] = data.readU8();
+                FC.PIDS[0][1] = data.readU8();
+                FC.PIDS[0][2] = data.readU8();
+                FC.ADVANCED_TUNING.dMinRoll = data.readU8();
+                FC.ADVANCED_TUNING.feedforwardRoll = data.readU16();
+
+                if (FC.TUNING_SLIDERS.slider_pids_mode > 1) {
+                    FC.PIDS[1][0] = data.readU8();
+                    FC.PIDS[1][1] = data.readU8();
+                    FC.PIDS[1][2] = data.readU8();
+                    FC.ADVANCED_TUNING.dMinPitch = data.readU8();
+                    FC.ADVANCED_TUNING.feedforwardPitch = data.readU16();
+                }
+
+                if (FC.TUNING_SLIDERS.slider_pids_mode > 2) {
+                    FC.PIDS[2][0] = data.readU8();
+                    FC.PIDS[2][1] = data.readU8();
+                    FC.PIDS[2][2] = data.readU8();
+                    FC.ADVANCED_TUNING.dMinYaw = data.readU8();
+                    FC.ADVANCED_TUNING.feedforwardYaw = data.readU16();
+                }
+
                 break;
 
             case MSPCodes.MSP_CALC_GYRO_TUNING_SLIDERS:
@@ -2349,6 +2370,7 @@ MspHelper.prototype.crunch = function(code) {
 
         case MSPCodes.MSP_SET_TUNING_SLIDERS:
             buffer
+            .push8(0) // set sliders values, don't apply
             .push8(FC.TUNING_SLIDERS.slider_pids_mode)
             .push8(FC.TUNING_SLIDERS.slider_master_multiplier)
             .push8(FC.TUNING_SLIDERS.slider_roll_pitch_ratio)
@@ -2358,10 +2380,20 @@ MspHelper.prototype.crunch = function(code) {
             .push8(FC.TUNING_SLIDERS.slider_dmax_gain)
             .push8(FC.TUNING_SLIDERS.slider_feedforward_gain)
             .push8(FC.TUNING_SLIDERS.slider_pitch_pi_gain)
+
             .push8(FC.TUNING_SLIDERS.slider_dterm_filter)
             .push8(FC.TUNING_SLIDERS.slider_dterm_filter_multiplier)
+            .push16(FC.FILTER_CONFIG.dterm_lowpass_hz)
+            .push16(FC.FILTER_CONFIG.dterm_lowpass2_hz)
+            .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz)
+            .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz)
+
             .push8(FC.TUNING_SLIDERS.slider_gyro_filter)
-            .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier);
+            .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier)
+            .push16(FC.FILTER_CONFIG.gyro_lowpass_hz)
+            .push16(FC.FILTER_CONFIG.gyro_lowpass2_hz)
+            .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz)
+            .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz);
 
             break;
         case MSPCodes.MSP_CALC_PID_TUNING_SLIDERS:
@@ -2380,6 +2412,8 @@ MspHelper.prototype.crunch = function(code) {
 
         case MSPCodes.MSP_CALC_GYRO_TUNING_SLIDERS:
             buffer
+            .push8(FC.TUNING_SLIDERS.slider_gyro_filter)
+            .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier)
             .push16(FC.FILTER_CONFIG.gyro_lowpass_hz)
             .push16(FC.FILTER_CONFIG.gyro_lowpass2_hz)
             .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz)
@@ -2388,6 +2422,8 @@ MspHelper.prototype.crunch = function(code) {
             break;
         case MSPCodes.MSP_CALC_DTERM_TUNING_SLIDERS:
             buffer
+            .push8(FC.TUNING_SLIDERS.slider_dterm_filter)
+            .push8(FC.TUNING_SLIDERS.slider_dterm_filter_multiplier)
             .push16(FC.FILTER_CONFIG.dterm_lowpass_hz)
             .push16(FC.FILTER_CONFIG.dterm_lowpass2_hz)
             .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz)

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -918,6 +918,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         gyroLowpassFilterMode.val(1).change();
                     }
                 }
+
                 gyroLowpassOption.toggle(checked);
                 gyroLowpassOptionStatic.toggle(checked && FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz === 0);
                 gyroLowpassOptionDynamic.toggle(checked && FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz !== 0);
@@ -927,7 +928,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 const dynMode = parseInt($(this).val());
 
                 if (TuningSliders.sliderGyroFilter) {
-                    TuningSliders.readSimplifiedGyroFilters();
+                    self.calculateNewGyroFilters();
 
                     gyroLowpassFrequency.val(FC.FILTER_CONFIG.gyro_lowpass_hz);
                     gyroLowpassDynMinFrequency.val(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz);
@@ -943,7 +944,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 }
 
                 gyroLowpassOptionStatic.toggle(!dynMode);
-                gyroLowpassOptionDynamic.toggle(dynMode);
+                gyroLowpassOptionDynamic.toggle(!!dynMode);
             });
 
             // switch gyro lpf2
@@ -952,9 +953,10 @@ TABS.pid_tuning.initialize = function (callback) {
                 let cutoff = FC.FILTER_CONFIG.gyro_lowpass2_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass2_hz : FILTER_DEFAULT.gyro_lowpass2_hz;
 
                 if (checked && TuningSliders.sliderGyroFilter && FC.FILTER_CONFIG.gyro_lowpass2_hz === 0) {
-                    TuningSliders.readSimplifiedGyroFilters();
+                    self.calculateNewGyroFilters();
                     cutoff = FC.FILTER_CONFIG.gyro_lowpass2_hz;
                 }
+
                 gyroLowpass2Frequency.val(checked ? cutoff : 0).attr('disabled', !checked);
                 gyroLowpass2Option.toggle(checked);
                 self.updateFilterWarning();
@@ -981,6 +983,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         dtermLowpassFilterMode.val(1).change();
                     }
                 }
+
                 dtermLowpassOption.toggle(checked);
                 dtermLowpassOptionStatic.toggle(checked && FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz === 0);
                 dtermLowpassOptionDynamic.toggle(checked && FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz !== 0);
@@ -990,7 +993,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 const dynMode = parseInt($(this).val());
 
                 if (TuningSliders.sliderDtermFilter) {
-                    TuningSliders.readSimplifiedDTermFilters();
+                    self.calculateNewDTermFilters();
                     dtermLowpassFrequency.val(FC.FILTER_CONFIG.dterm_lowpass_hz);
                     dtermLowpassDynMinFrequency.val(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz);
                     dtermLowpassDynMaxFrequency.val(FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
@@ -1003,15 +1006,16 @@ TABS.pid_tuning.initialize = function (callback) {
                     dtermLowpassDynMinFrequency.val(dynMode ? cutoffMin : 0);
                     dtermLowpassDynMaxFrequency.val(dynMode ? cutoffMax : 0);
                 }
+
                 dtermLowpassOptionStatic.toggle(!dynMode);
-                dtermLowpassOptionDynamic.toggle(dynMode);
+                dtermLowpassOptionDynamic.toggle(!!dynMode);
             });
 
             dtermLowpass2Enabled.change(function() {
                 const checked = $(this).is(':checked');
                 let cutoff = FC.FILTER_CONFIG.dterm_lowpass2_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass2_hz : FILTER_DEFAULT.dterm_lowpass2_hz;
                 if (checked && TuningSliders.sliderDTermFilter && FC.FILTER_CONFIG.dterm_lowpass2_hz === 0) {
-                    TuningSliders.readSimplifiedDTermFilters();
+                    self.calculateNewDTermFilters();
                     cutoff = FC.FILTER_CONFIG.dterm_lowpass2_hz;
                 }
 
@@ -2215,7 +2219,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
                 sliderGyroFilterModeSelect.change(function() {
                     const mode = parseInt($(this).find(':selected').val());
-                    if (mode === 0) {
+                    if (mode === 1) {
                         TuningSliders.gyroFilterSliderEnable();
                     } else {
                         TuningSliders.gyroFilterSliderDisable();
@@ -2225,7 +2229,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
                 sliderDTermFilterModeSelect.change(function() {
                     const mode = parseInt($(this).find(':selected').val());
-                    if (mode === 0) {
+                    if (mode !== 0) {
                         TuningSliders.dtermFilterSliderEnable();
                     } else {
                         TuningSliders.dtermFilterSliderDisable();
@@ -2483,7 +2487,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         $(`.pid_filter select[name="${e.target.name}"]`).val(e.target.value);
                     }
                 }
-                TuningSliders.updateFilterSlidersDisplay();
+
                 if (TuningSliders.GyroSliderUnavailable) {
                     self.analyticsChanges['GyroFilterTuningSlider'] = "Off";
                 }
@@ -2693,6 +2697,7 @@ TABS.pid_tuning.saveInitialSettings = function () {
 
 TABS.pid_tuning.restoreInitialSettings = function () {
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+        /*  todo: rewrite
         FC.PIDS = this.copyMultiArray(this.CONFIGURATOR_PIDS);
         FC.ADVANCED_TUNING = { ...this.CONFIGURATOR_ADVANCED_TUNING };
         FC.FILTER_CONFIG = { ...this.CONFIGURATOR_FILTER_CONFIG };
@@ -2712,6 +2717,7 @@ TABS.pid_tuning.restoreInitialSettings = function () {
 
             console.log('Configuration restored to initial values');
         });
+        */
     }
 };
 

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -909,7 +909,6 @@ TABS.pid_tuning.initialize = function (callback) {
                         gyroLowpassDynMinFrequency.val(0);
                         gyroLowpassDynMaxFrequency.val(0);
                         gyroLowpassFrequency.val(0);
-                        self.updateFiltersInFirmware('gyro');
                     }
                 } else {
                     // lowpass 1 is disabled, set the master switch off, only show label
@@ -926,36 +925,25 @@ TABS.pid_tuning.initialize = function (callback) {
 
             gyroLowpassFilterMode.change(function() {
                 const dynMode = parseInt($(this).val());
-                let cutoff = FC.FILTER_CONFIG.gyro_lowpass_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass_hz : FILTER_DEFAULT.gyro_lowpass_hz;
-                let cutoffMin = FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz : FILTER_DEFAULT.gyro_lowpass_dyn_min_hz;
-                let cutoffMax = FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz : FILTER_DEFAULT.gyro_lowpass_dyn_max_hz;
 
                 if (TuningSliders.sliderGyroFilter) {
-                    if (FC.FILTER_CONFIG.gyro_lowpass_hz === 0) {
-                        cutoff = Math.round(TuningSliders.sliderGyroFilterMultiplier * FILTER_DEFAULT.gyro_lowpass_hz);
-                    }
-                    if (FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz === 0) {
-                        cutoffMin = Math.round(TuningSliders.sliderGyroFilterMultiplier * FILTER_DEFAULT.gyro_lowpass_dyn_min_hz);
-                        cutoffMax = Math.round(TuningSliders.sliderGyroFilterMultiplier * FILTER_DEFAULT.gyro_lowpass_dyn_max_hz);
-                    }
+                    TuningSliders.readSimplifiedGyroFilters();
+
+                    gyroLowpassFrequency.val(FC.FILTER_CONFIG.gyro_lowpass_hz);
+                    gyroLowpassDynMinFrequency.val(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz);
+                    gyroLowpassDynMaxFrequency.val(FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz);
+                } else {
+                    const cutoff = FC.FILTER_CONFIG.gyro_lowpass_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass_hz : FILTER_DEFAULT.gyro_lowpass_hz;
+                    const cutoffMin = FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz : FILTER_DEFAULT.gyro_lowpass_dyn_min_hz;
+                    const cutoffMax = FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz : FILTER_DEFAULT.gyro_lowpass_dyn_max_hz;
+
+                    gyroLowpassFrequency.val(dynMode ? 0 : cutoff);
+                    gyroLowpassDynMinFrequency.val(dynMode ? cutoffMin : 0);
+                    gyroLowpassDynMaxFrequency.val(dynMode ? cutoffMax : 0);
                 }
 
-                if (dynMode) {
-                    gyroLowpassFrequency.val(0);
-                    gyroLowpassDynMinFrequency.val(cutoffMin);
-                    gyroLowpassDynMaxFrequency.val(cutoffMax);
-                    gyroLowpassOptionStatic.hide();
-                    gyroLowpassOptionDynamic.show();
-                    self.updateFiltersInFirmware('gyro');
-                } else {
-                    // static, set the dynamic field min to zero
-                    gyroLowpassDynMinFrequency.val(0);
-                    gyroLowpassDynMaxFrequency.val(0);
-                    gyroLowpassFrequency.val(cutoff);
-                    gyroLowpassOptionStatic.show();
-                    gyroLowpassOptionDynamic.hide();
-                    self.updateFiltersInFirmware('gyro');
-                }
+                gyroLowpassOptionStatic.toggle(!dynMode);
+                gyroLowpassOptionDynamic.toggle(dynMode);
             });
 
             // switch gyro lpf2
@@ -964,11 +952,11 @@ TABS.pid_tuning.initialize = function (callback) {
                 let cutoff = FC.FILTER_CONFIG.gyro_lowpass2_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass2_hz : FILTER_DEFAULT.gyro_lowpass2_hz;
 
                 if (checked && TuningSliders.sliderGyroFilter && FC.FILTER_CONFIG.gyro_lowpass2_hz === 0) {
-                    cutoff = Math.round(TuningSliders.sliderGyroFilterMultiplier * FILTER_DEFAULT.gyro_lowpass2_hz);
+                    TuningSliders.readSimplifiedGyroFilters();
+                    cutoff = FC.FILTER_CONFIG.gyro_lowpass2_hz;
                 }
                 gyroLowpass2Frequency.val(checked ? cutoff : 0).attr('disabled', !checked);
                 gyroLowpass2Option.toggle(checked);
-                self.updateFiltersInFirmware('gyro');
                 self.updateFilterWarning();
             });
 
@@ -984,7 +972,6 @@ TABS.pid_tuning.initialize = function (callback) {
                         dtermLowpassDynMinFrequency.val(0);
                         dtermLowpassDynMaxFrequency.val(0);
                         dtermLowpassFrequency.val(0);
-                        self.updateFiltersInFirmware('dterm');
                     }
                 } else {
                     // lowpass 1 is disabled, set the master switch off, only show label
@@ -1001,48 +988,35 @@ TABS.pid_tuning.initialize = function (callback) {
 
             dtermLowpassFilterMode.change(function() {
                 const dynMode = parseInt($(this).val());
-                let cutoff = FC.FILTER_CONFIG.dterm_lowpass_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass_hz : FILTER_DEFAULT.dterm_lowpass_hz;
-                let cutoffMin = FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz : FILTER_DEFAULT.dterm_lowpass_dyn_min_hz;
-                let cutoffMax = FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz : FILTER_DEFAULT.dterm_lowpass_dyn_max_hz;
 
-                if (TuningSliders.sliderGyroFilter) {
-                    if (FC.FILTER_CONFIG.dterm_lowpass_hz === 0) {
-                        cutoff = Math.round(TuningSliders.sliderDTermFilterMultiplier * FILTER_DEFAULT.dterm_lowpass_hz);
-                    }
-                    if (FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz === 0) {
-                        cutoffMin = Math.round(TuningSliders.sliderDTermFilterMultiplier * FILTER_DEFAULT.dterm_lowpass_dyn_min_hz);
-                        cutoffMax = Math.round(TuningSliders.sliderDTermFilterMultiplier * FILTER_DEFAULT.dterm_lowpass_dyn_max_hz);
-                    }
-                }
-
-                if (dynMode) {
-                    dtermLowpassFrequency.val(0);
-                    dtermLowpassDynMinFrequency.val(cutoffMin);
-                    dtermLowpassDynMaxFrequency.val(cutoffMax);
-                    dtermLowpassOptionStatic.hide();
-                    dtermLowpassOptionDynamic.show();
-                    self.updateFiltersInFirmware('dterm');
+                if (TuningSliders.sliderDtermFilter) {
+                    TuningSliders.readSimplifiedDTermFilters();
+                    dtermLowpassFrequency.val(FC.FILTER_CONFIG.dterm_lowpass_hz);
+                    dtermLowpassDynMinFrequency.val(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz);
+                    dtermLowpassDynMaxFrequency.val(FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
                 } else {
-                    // static, set the dynamic field min to zero
-                    dtermLowpassDynMinFrequency.val(0);
-                    dtermLowpassDynMaxFrequency.val(0);
-                    dtermLowpassFrequency.val(cutoff);
-                    dtermLowpassOptionStatic.show();
-                    dtermLowpassOptionDynamic.hide();
-                    self.updateFiltersInFirmware('dterm');
+                    const cutoff = FC.FILTER_CONFIG.dterm_lowpass_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass_hz : FILTER_DEFAULT.dterm_lowpass_hz;
+                    const cutoffMin = FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz : FILTER_DEFAULT.dterm_lowpass_dyn_min_hz;
+                    const cutoffMax = FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz : FILTER_DEFAULT.dterm_lowpass_dyn_max_hz;
+
+                    dtermLowpassFrequency.val(dynMode ? 0 : cutoff);
+                    dtermLowpassDynMinFrequency.val(dynMode ? cutoffMin : 0);
+                    dtermLowpassDynMaxFrequency.val(dynMode ? cutoffMax : 0);
                 }
+                dtermLowpassOptionStatic.toggle(!dynMode);
+                dtermLowpassOptionDynamic.toggle(dynMode);
             });
 
             dtermLowpass2Enabled.change(function() {
                 const checked = $(this).is(':checked');
                 let cutoff = FC.FILTER_CONFIG.dterm_lowpass2_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass2_hz : FILTER_DEFAULT.dterm_lowpass2_hz;
                 if (checked && TuningSliders.sliderDTermFilter && FC.FILTER_CONFIG.dterm_lowpass2_hz === 0) {
-                    cutoff = Math.round(TuningSliders.sliderDTermFilterMultiplier * FILTER_DEFAULT.dterm_lowpass2_hz);
+                    TuningSliders.readSimplifiedDTermFilters();
+                    cutoff = FC.FILTER_CONFIG.dterm_lowpass2_hz;
                 }
 
                 dtermLowpass2Frequency.val(checked ? cutoff : 0).attr('disabled', !checked);
                 dtermLowpass2Option.toggle(checked);
-                self.updateFiltersInFirmware('dterm');
                 self.updateFilterWarning();
             });
         }
@@ -3044,12 +3018,6 @@ TABS.pid_tuning.updateRatesLabels = function() {
 
             stickContext.restore();
         }
-    }
-};
-
-TABS.pid_tuning.updateFiltersInFirmware = function(param) {
-    if (!TABS.pid_tuning.isHtmlProcessing) {
-        TuningSliders.updateFiltersInFirmware(param);
     }
 };
 


### PR DESCRIPTION
Made a couple of updates to the Firmware PR, so please make sure you use the latest from there.

What this PR does (mainly removing 😃 ):

1. Correct new MSP commands IN and OUT
2. Correct reaction on these new MSP commands
3. Removed some unnecessary MSP requests.
4. Removed slider calculations on TAB initialization.
5. Removed timeout when jumping on the other tabs.
6. Removed reset function.
7. Some typos.

the tab now "SORT OF WORKS" - it still requires some cleaning:
I still see sometimes unnecessary MSP commands going on

1. Need to grey out filter settings when sliders are active
2. Need to fix weird scenarios when the user puts min_hz > max_hz in the configurator.
3. Need to add warnings when the configuration is broken (p_roll = 200 etc) - but that could be separate PR.
4. Need to check if I broke 4.2
5. .....