### PR TITLE
FW silders: dterm slider fix + css for input fields

### DIFF
--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -255,7 +255,6 @@
     text-align: right;
     border: 1px solid var(--subtleAccent);
     border-radius: 3px;
-    background-color: #f9f9f9;
 }
 
 .tab-pid_tuning .subtab-filter table input,

--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -148,7 +148,7 @@ TuningSliders.updateExpertModeSlidersDisplay = function() {
     $('.baseSliderPIGain').toggleClass('disabledSliders', piGain && !this.expertMode);
     $('.baseSliderFeedforwardGain').toggleClass('disabledSliders', ffGain && !this.expertMode);
 
-    $('.advancedSlider').toggleClass('disabledSliders', !this.expertMode);
+    $('.advancedSlider').toggleClass('disabledSliders', !this.sliderPidsMode || !this.expertMode);
 
     $('.advancedSliderDmaxGain').toggle(dMaxGain || this.expertMode);
     $('.advancedSliderIGain').toggle(iGain || this.expertMode);
@@ -348,7 +348,7 @@ TuningSliders.updatePidSlidersDisplay = function() {
         $('#pid_main .YAW .pid_data input').each((_, el) => $(el).prop('disabled', this.sliderPidsMode === 2));
 
         $('.baseSlider').toggleClass('disabledSliders', !this.sliderPidsMode);
-        $('.advancedSlider').toggleClass('disabledSliders', !this.sliderPidsMode);
+        $('.advancedSlider').toggleClass('disabledSliders', !this.sliderPidsMode || !this.expertMode);
 
         $('#sliderDGain').prop('disabled', !this.sliderPidsMode);
         $('#sliderPIGain').prop('disabled', !this.sliderPidsMode);

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -992,7 +992,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 dtermLowpassDynMinFrequency.val(dynMode ? cutoffMin : 0);
                 dtermLowpassDynMaxFrequency.val(dynMode ? cutoffMax : 0);
 
-                if (TuningSliders.sliderDtermFilter) {
+                if (TuningSliders.sliderDTermFilter) {
                     self.calculateNewDTermFilters();
                 }
 


### PR DESCRIPTION
1. Fix dterm dynamic LPF after enabling it
2. CSS fix for the background of enabled fields on pid tab.
3. Fix when loading PID tab with non-default expert sliders in non-expert mode