### PR TITLE
Fix: Disconnect button color inconsistency between light and dark themes

### DIFF
--- a/src/components/port-picker/ConnectButton.vue
+++ b/src/components/port-picker/ConnectButton.vue
@@ -307,13 +307,33 @@ export default defineComponent({
 }
 
 /* Default Nuxt UI `success` soft tint is too pale in light mode — lift the contrast. */
-html:not(.dark) .sidebar-connect :deep(button) {
+html:not(.dark) .sidebar-connect :deep(button.color-success) {
     background-color: var(--success-400);
     border: 1px solid var(--success-600);
     color: var(--surface-900);
 }
-html:not(.dark) .sidebar-connect :deep(button:hover) {
+html:not(.dark) .sidebar-connect :deep(button.color-success:hover) {
     background-color: var(--success-500);
+}
+
+/* Disconnect button (error) styling for light mode - ensure it's red */
+html:not(.dark) .sidebar-connect :deep(button.color-error) {
+    background-color: var(--error-500);
+    border: 1px solid var(--error-600);
+    color: var(--surface-50);
+}
+html:not(.dark) .sidebar-connect :deep(button.color-error:hover) {
+    background-color: var(--error-600);
+}
+
+/* Disconnect button (error) styling for dark mode - ensure proper contrast */
+html.dark .sidebar-connect :deep(button.color-error) {
+    background-color: var(--error-500);
+    border: 1px solid var(--error-600);
+    color: var(--surface-50);
+}
+html.dark .sidebar-connect :deep(button.color-error:hover) {
+    background-color: var(--error-600);
 }
 
 .tab_container.reveal .sidebar-connect {


### PR DESCRIPTION
This PR fixes the bug where the disconnect button appeared GREEN in light mode but RED in dark mode.

## Changes

### src/components/port-picker/ConnectButton.vue
- Changed broad `:deep(button)` selector to `:deep(button.color-success)` to only target success-colored buttons
- Added explicit CSS for `:deep(button.color-error)` in both light and dark modes
- The disconnect button now consistently appears RED in both themes
- The connect button continues to work with appropriate success color styling

### issues.md
- Created with full bug analysis and fix documentation

## Root Cause
The CSS had a broad `:deep(button)` selector that applied success colors (green) to ALL buttons in light mode, including the disconnect button which should be red.

## Testing
Verify that:
- Connect button is GREEN in both light and dark themes
- Disconnect button is RED in both light and dark themes
- Both buttons have proper text contrast